### PR TITLE
Additional User Data Accessibility

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1,4 +1,6 @@
 const UserModel = require("../models/User");
+const ProfessionalModel = require("../models/HealthcareProvider");
+const PatientModel = require("../models/Patient");
 
 module.exports = {
   getUser: (req, res) => {
@@ -22,10 +24,27 @@ module.exports = {
 
     UserModel.findUser({ id: userID })
       .then((user) => {
-        return res.status(200).json({
-          status: true,
-          data: user.toJSON(),
-        });
+        if (user.role === "patient") {
+          PatientModel.findUser({ id: userID }).then((patient) => {
+            return res.status(200).json({
+              status: true,
+              userData: user.toJSON(),
+              patientData: patient.toJSON(),
+            });
+          });
+        } else if (user.role === "provider") {
+          ProfessionalModel.findProvider({ id: userID }).then(
+            (professional) => {
+              return res.status(200).json({
+                status: true,
+                userData: user.toJSON(),
+                professionalData: professional.toJSON(),
+              });
+            }
+          );
+        } else {
+          return res.status(200).json({ status: true, userData: user.toJSON });
+        }
       })
       .catch((err) => {
         return res.status(500).json({

--- a/api/routes/LabResultRoutes.js
+++ b/api/routes/LabResultRoutes.js
@@ -9,19 +9,11 @@ const LabResultController = require("../controllers/LabResultController");
 
 const GetRole = require("../helpers/GetRole");
 
-router.get("/", isAuthenticatedMiddleware.check, (req, res) => {
-  const userRole = GetRole(req.user).role;
-
-  if (userRole === "patient") {
-    return LabResultController.getLabResultById;
-  } else if (userRole === "admin") {
-    return LabResultController.getAllLabResults;
-  } else {
-    return res
-      .status(403)
-      .json({ success: false, message: "Unauthorized access" });
-  }
-});
+router.get(
+  "/",
+  [isAuthenticatedMiddleware.check, CheckPermissionMiddleware.has("admin")],
+  LabResultController.getAllLabResults
+);
 
 router.get("/:id", isAuthenticatedMiddleware.check, (req, res) => {
   const userRole = GetRole(req.user).role;


### PR DESCRIPTION
Now when logging in the response includes all additional data for Patients and Professionals.

Old Output:
```json
{
"status": "Boolean",
"userData": {}
}
```
New Output:
```json
{
"status": "Boolean",
"userData": {},
"patientData": {} // Or professionalData in case the user is a professional ** This does not apply to admins
}
```

P.S: I also tweaked a logical error in lab results routes